### PR TITLE
Honor AEAD choice in sing-box socks configs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7488,6 +7488,7 @@ setSocks5Inbound() {
           "listen":"::",
           "listen_port":${result[-1]},
           "tag":"socks5_inbound",
+          "auth":"${socks5InboundAuthType}",
           "users":[
             {
                   "username": "${socks5InboundUserName}",
@@ -7651,6 +7652,7 @@ EOF
           "server": "${socks5RoutingOutboundIP}",
           "server_port": ${socks5RoutingOutboundPort},
           "version": "5",
+          "auth": "${socks5RoutingOutboundAuthType}",
 ${socks5OutboundUsers}${socks5DetourConfig}
         }
     ]


### PR DESCRIPTION
## Summary
- propagate socks inbound authentication selection to sing-box by emitting the chosen auth mode
- include the selected socks outbound auth type in sing-box configuration so AEAD clients are generated correctly

## Testing
- bash -n install.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d0d4b4a5c832785f44a1b2497242b)