### PR TITLE
Update self-updater to use current repository

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6357,9 +6357,9 @@ updateV2RayAgent() {
     echoContent skyBlue "\n进度  $1/${totalProgress} : 更新v2ray-agent脚本"
     rm -rf /etc/v2ray-agent/install.sh
     if [[ "${release}" == "alpine" ]]; then
-        wget -c -q -P /etc/v2ray-agent/ -N "https://raw.githubusercontent.com/mack-a/v2ray-agent/master/install.sh"
+        wget -c -q -P /etc/v2ray-agent/ -N "https://raw.githubusercontent.com/Lynthar/Proxy-agent/master/install.sh"
     else
-        wget -c -q "${wgetShowProgressStatus}" -P /etc/v2ray-agent/ -N "https://raw.githubusercontent.com/mack-a/v2ray-agent/master/install.sh"
+        wget -c -q "${wgetShowProgressStatus}" -P /etc/v2ray-agent/ -N "https://raw.githubusercontent.com/Lynthar/Proxy-agent/master/install.sh"
     fi
 
     sudo chmod 700 /etc/v2ray-agent/install.sh
@@ -6370,7 +6370,7 @@ updateV2RayAgent() {
     echoContent yellow " ---> 请手动执行[vasma]打开脚本"
     echoContent green " ---> 当前版本：${version}\n"
     echoContent yellow "如更新不成功，请手动执行下面命令\n"
-    echoContent skyBlue "wget -P /root -N https://raw.githubusercontent.com/mack-a/v2ray-agent/master/install.sh && chmod 700 /root/install.sh && /root/install.sh"
+    echoContent skyBlue "wget -P /root -N https://raw.githubusercontent.com/Lynthar/Proxy-agent/master/install.sh && chmod 700 /root/install.sh && /root/install.sh"
     echo
     exit 0
 }
@@ -8026,22 +8026,28 @@ setSocks5Outbound() {
     read -r -p "探测间隔(默认30s):" socks5HealthCheckInterval
     echo
 
+    # 仅当指定配置文件目录时才生成 sing-box 出站 JSON
     if [[ -n "${singBoxConfigPath}" ]]; then
+        local socks5ConfigFile="${singBoxConfigPath}socks5_outbound.json"
+
+        # 提前设置 healthcheck 默认值，保证后续使用一致
+        socks5HealthCheckURL=${socks5HealthCheckURL:-https://www.gstatic.com/generate_204}
+        socks5HealthCheckInterval=${socks5HealthCheckInterval:-30s}
+
         # detour + healthcheck 配置变量初始化
         local socks5DetourConfig=
         local socks5HealthcheckConfig=
-        # 这里继续保留 master 分支中基于 socks5RoutingProxyTagList[*] 的 detour 构造逻辑
-        if [[ -n "${socks5RoutingProxyTagList[*]}" ]]; then
-            # ... 原来 master 里的 detour 构造代码 ...
-        fi
-    fi
 
+        # 基于 socks5RoutingProxyTagList[*] 的 detour 构造逻辑
+        if [[ -n "${socks5RoutingProxyTagList[*]}" ]]; then
             read -r -d '' socks5DetourConfig <<EOF || true
 ,
           "detour":"${socks5RoutingProxyTagList[0]}"
 EOF
         fi
+
         # TLS / transport 相关配置（来自 codex/add-transport-options-to-socks-wizard 分支）
+        # 使用显式的 TLS/transport 片段，避免 JSON 拼接时遗漏逗号或缩进
         local socks5SingBoxTLSConfig=
         local socks5SingBoxTransportConfig=
         if [[ "${socks5TransportType}" != "1" ]]; then
@@ -8102,24 +8108,23 @@ EOF
 ,
           "healthcheck": {
               "enable": true,
-              "url": "${socks5HealthCheckURL:-https://www.gstatic.com/generate_204}",
-              "interval": "${socks5HealthCheckInterval:-30s}"${socks5HealthCheckDestinationConfig}
+              "url": "${socks5HealthCheckURL}",
+              "interval": "${socks5HealthCheckInterval}"${socks5HealthCheckDestinationConfig}
           }
 EOF
         fi
 
-        cat <<EOF >"${singBoxConfigPath}socks5_outbound.json"
+        # 按国际通用风格输出 JSON，便于读写和后续审计
+        cat <<EOF >"${socks5ConfigFile}"
 {
-    "outbounds":[
+    "outbounds": [
         {
           "type": "socks",
-          "tag":"socks5_outbound",
+          "tag": "socks5_outbound",
           "server": "${socks5RoutingOutboundIP}",
           "server_port": ${socks5RoutingOutboundPort},
           "version": "5",
         ${socks5OutboundUsers}${socks5DetourConfig}${socks5HealthcheckConfig}${socks5SingBoxTLSConfig}${socks5SingBoxTransportConfig}
-        }
-
         }
     ]
 }


### PR DESCRIPTION
## Summary
- download updates from this repository instead of the original upstream when running the self-update routine
- adjust manual update hint to reference the local repository URL

## Testing
- bash -n install.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d13892dcc8327a9ef62dae1f99438)