### PR TITLE
Fix SOCKS5 routing issues for sing-box

### DIFF
--- a/documents/code_review_report.md
+++ b/documents/code_review_report.md
@@ -377,4 +377,41 @@ elif [[ "${socks5InboundDomainStrategyStatus}" == "2" ]]; then
 
 ---
 
-*报告生成日期: 2025-12-13*
+---
+
+## 7. 已修复的问题 (2025-12-13)
+
+### 7.1 sing-box SOCKS5 入站 aead 字段错误 (已修复)
+
+**原问题**: `install.sh:7863` 中为 SOCKS 入站添加了不存在的 `aead` 字段
+
+```bash
+| (if $enableAead then .inbounds[0].users[0].aead = true else . end)
+```
+
+**错误信息**:
+```
+FATAL[0000] decode config at /etc/v2ray-agent/sing-box/conf/config/20_socks5_inbounds.json: inbounds[0].users[0].aead: json: unknown field "aead"
+```
+
+**修复**: 移除了该行代码。sing-box SOCKS 入站只支持 `username` 和 `password` 字段。
+
+---
+
+### 7.2 全局 SOCKS 出站转发缺少路由配置 (已修复)
+
+**原问题**: `setSocks5OutboundRoutingAll` 函数只删除了其他路由规则，但没有创建让所有流量走 `socks5_outbound` 的路由配置。这导致使用 Reality 协议时流量无法正确转发。
+
+**修复**: 在函数中添加了创建全局路由配置的代码：
+
+```json
+{
+  "route": {
+    "final": "socks5_outbound"
+  }
+}
+```
+
+---
+
+*报告更新日期: 2025-12-13*

--- a/install.sh
+++ b/install.sh
@@ -7623,7 +7623,8 @@ setSocks5OutboundRoutingAll() {
     echoContent red "=============================================================="
     echoContent yellow "# 注意事项\n"
     echoContent yellow "1.会删除所有已经设置的分流规则，包括其他分流（warp、IPv6等）"
-    echoContent yellow "2.会删除Socks5之外的所有出站规则\n"
+    echoContent yellow "2.会删除Socks5之外的所有出站规则"
+    echoContent yellow "3.所有入站流量将通过Socks5出站转发\n"
     read -r -p "是否确认设置？[y/n]:" socksOutStatus
 
     if [[ "${socksOutStatus}" == "y" ]]; then
@@ -7649,6 +7650,15 @@ setSocks5OutboundRoutingAll() {
 
             removeSingBoxConfig socks5_01_outbound_route
             removeSingBoxConfig 01_direct_outbound
+
+            # 创建全局路由配置，让所有流量走 socks5_outbound
+            cat <<EOF >"${singBoxConfigPath}socks5_01_outbound_route.json"
+{
+  "route": {
+    "final": "socks5_outbound"
+  }
+}
+EOF
         fi
 
         echoContent green " ---> Socks5全局出站设置完毕"
@@ -7860,7 +7870,6 @@ setSocks5Inbound() {
             }
           ]
         }
-        | (if $enableAead then .inbounds[0].users[0].aead = true else . end)
     ' >"${socks5InboundJsonFile}"; then
         rm -f "${socks5InboundJsonFile}"
         echoContent red " ---> 生成 Socks5 入站配置失败，请检查输入"


### PR DESCRIPTION
1. Remove invalid 'aead' field from sing-box SOCKS inbound config
   - sing-box SOCKS users only support 'username' and 'password' fields
   - Fixes: "json: unknown field aead" error on sing-box startup

2. Add global routing config for SOCKS5 outbound forwarding
   - setSocks5OutboundRoutingAll now creates route.final config
   - Ensures all inbound traffic (including Reality protocols) routes to socks5_outbound
   - Fixes: Reality protocols (vision-reality, reality-xhttp) not working when using SOCKS forwarding

These fixes resolve the SOCKS5 forwarding issues where TLS-vision worked but Reality protocols did not.