### PR TITLE
feat: Rename project to Proxy-agent and add language switch menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Proxy-agent
-- v2ray-agent的分支，感谢原作者mack-a的贡献
+
+基于 v2ray-agent 的分支，感谢原作者 mack-a 的贡献
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![English Version](https://img.shields.io/badge/English-Version-blue)](documents/en/README_EN.md)
@@ -16,21 +17,14 @@ Xray-core/sing-box 一键脚本快速安装
 *   **分流管理:** 提供wireguard、IPv6、Socks5、DNS、VMess(ws)、SNI反向代理，可用于解锁流媒体、规避IP验证等作用.
 *   **目标域名管理:** 提供域名黑名单管理，可用于禁止访问指定网站.
 *   **BT下载管理:** 可用于禁止下载P2P相关内容.
-*   **双语支持:** 提供中文和英文两个版本.
-*   **可在本仓库文档中查看使用说明**
+*   **双语支持:** 支持中文和英文界面，可随时切换.
 
 ## 快速开始
 
-### 中文版安装
+### 安装
 
 ```bash
 wget -P /root -N "https://raw.githubusercontent.com/Lynthar/Proxy-agent/master/install.sh" && chmod 700 /root/install.sh && /root/install.sh
-```
-
-### English Version Installation
-
-```bash
-wget -P /root -N "https://raw.githubusercontent.com/Lynthar/Proxy-agent/master/shell/install_en.sh" && chmod 700 /root/install_en.sh && /root/install_en.sh
 ```
 
 ### 使用
@@ -43,12 +37,41 @@ pasly
 
 ## 语言选择 / Language Selection
 
-| 语言 / Language | 安装脚本 / Script |
-|----------------|------------------|
-| 中文           | `install.sh`     |
-| English        | `install_en.sh`  |
+脚本支持中文和英文两种语言，有以下几种切换方式：
 
-两个版本功能完全相同，仅界面语言不同。
+### 方式1：在管理菜单中切换（推荐）
+
+```bash
+pasly
+# 选择菜单项 21.切换语言 / Switch Language
+```
+
+### 方式2：首次安装时指定语言
+
+```bash
+# 安装英文版
+V2RAY_LANG=en bash install.sh
+
+# 安装中文版（默认）
+V2RAY_LANG=zh bash install.sh
+```
+
+### 方式3：临时使用指定语言
+
+```bash
+V2RAY_LANG=en pasly   # 英文界面
+V2RAY_LANG=zh pasly   # 中文界面
+```
+
+语言设置会被持久保存到 `/etc/Proxy-agent/lang_pref`，后续使用 `pasly` 时会自动加载。
+
+## 安装目录
+
+脚本安装后的配置目录：`/etc/Proxy-agent/`
+
+## 从旧版本迁移
+
+如果你之前使用的是 `/etc/v2ray-agent/` 目录，脚本会在首次运行时自动迁移到 `/etc/Proxy-agent/`，无需手动操作。
 
 ## 文档和指南
 

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -74,9 +74,9 @@ readonly PROTOCOL_ANYTLS=13
 readonly PROTOCOL_SS2022=14
 
 # 配置文件路径
-readonly XRAY_CONFIG_DIR="/etc/v2ray-agent/xray/conf"
-readonly SINGBOX_CONFIG_DIR="/etc/v2ray-agent/sing-box/conf/config"
-readonly TLS_DIR="/etc/v2ray-agent/tls"
+readonly XRAY_CONFIG_DIR="/etc/Proxy-agent/xray/conf"
+readonly SINGBOX_CONFIG_DIR="/etc/Proxy-agent/sing-box/conf/config"
+readonly TLS_DIR="/etc/Proxy-agent/tls"
 ```
 
 ### 1.2 utils.sh

--- a/lib/config-reader.sh
+++ b/lib/config-reader.sh
@@ -16,23 +16,23 @@ readonly _CONFIG_READER_LOADED=1
 # ============================================================================
 
 # Xray配置路径
-: "${XRAY_CONFIG_BASE:=/etc/v2ray-agent/xray}"
+: "${XRAY_CONFIG_BASE:=/etc/Proxy-agent/xray}"
 : "${XRAY_CONFIG_PATH:=${XRAY_CONFIG_BASE}/conf/}"
 : "${XRAY_BINARY:=${XRAY_CONFIG_BASE}/xray}"
 
 # sing-box配置路径
-: "${SINGBOX_CONFIG_BASE:=/etc/v2ray-agent/sing-box}"
+: "${SINGBOX_CONFIG_BASE:=/etc/Proxy-agent/sing-box}"
 : "${SINGBOX_CONFIG_PATH:=${SINGBOX_CONFIG_BASE}/conf/config/}"
 : "${SINGBOX_BINARY:=${SINGBOX_CONFIG_BASE}/sing-box}"
 
 # TLS证书路径
-: "${TLS_PATH:=/etc/v2ray-agent/tls/}"
+: "${TLS_PATH:=/etc/Proxy-agent/tls/}"
 
 # Nginx配置路径
 : "${NGINX_CONFIG_PATH:=/etc/nginx/conf.d/}"
 
 # 订阅路径
-: "${SUBSCRIBE_LOCAL_PATH:=/etc/v2ray-agent/subscribe_local/}"
+: "${SUBSCRIBE_LOCAL_PATH:=/etc/Proxy-agent/subscribe_local/}"
 
 # ============================================================================
 # 核心检测函数
@@ -455,7 +455,7 @@ readNginxSubscribeConfig() {
 # 读取WARP配置
 # 输出: JSON对象 {privateKey, address, publicKey, reserved}
 readWarpConfig() {
-    local configFile="/etc/v2ray-agent/warp/config"
+    local configFile="/etc/Proxy-agent/warp/config"
     [[ ! -f "${configFile}" ]] && return 1
 
     local privateKey address publicKey reserved

--- a/lib/constants.sh
+++ b/lib/constants.sh
@@ -37,7 +37,8 @@ readonly PROTOCOL_SOCKS5=20               # SOCKS5 (内部使用)
 # 配置目录路径
 # ============================================================================
 
-readonly V2RAY_AGENT_DIR="/etc/v2ray-agent"
+readonly PROXY_AGENT_DIR="/etc/Proxy-agent"
+readonly V2RAY_AGENT_DIR="${PROXY_AGENT_DIR}"  # 向后兼容别名
 readonly XRAY_CONFIG_DIR="${V2RAY_AGENT_DIR}/xray/conf"
 readonly SINGBOX_CONFIG_DIR="${V2RAY_AGENT_DIR}/sing-box/conf/config"
 readonly TLS_CERT_DIR="${V2RAY_AGENT_DIR}/tls"

--- a/lib/i18n.sh
+++ b/lib/i18n.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# i18n Language Loader for v2ray-agent
+# i18n Language Loader for Proxy-agent
 # 国际化语言加载器
 # =============================================================================
 # Usage:
@@ -13,10 +13,23 @@ _I18N_DIR="${_SCRIPT_DIR:-$(dirname "${BASH_SOURCE[0]}")/..}/shell/lang"
 
 # =============================================================================
 # 语言检测 - Language Detection
-# 优先级: V2RAY_LANG > LANGUAGE > LANG > 默认中文
+# 优先级: V2RAY_LANG > 持久配置文件 > LANGUAGE > LANG > 默认中文
 # =============================================================================
 _detect_language() {
-    local lang="${V2RAY_LANG:-${LANGUAGE:-${LANG:-zh_CN}}}"
+    local lang=""
+    local langFile="/etc/Proxy-agent/lang_pref"
+
+    # 优先级1: 环境变量 V2RAY_LANG
+    if [[ -n "${V2RAY_LANG}" ]]; then
+        lang="${V2RAY_LANG}"
+    # 优先级2: 持久化语言配置文件
+    elif [[ -f "${langFile}" ]]; then
+        lang=$(cat "${langFile}" 2>/dev/null)
+    # 优先级3: 系统环境变量
+    else
+        lang="${LANGUAGE:-${LANG:-zh_CN}}"
+    fi
+
     case "${lang}" in
         en*|EN*) echo "en_US" ;;
         zh*|ZH*|*) echo "zh_CN" ;;  # 默认中文

--- a/lib/json-utils.sh
+++ b/lib/json-utils.sh
@@ -15,7 +15,7 @@ readonly _JSON_UTILS_LOADED=1
 # ============================================================================
 
 # JSON临时文件前缀
-readonly JSON_TMP_PREFIX="/tmp/v2ray-agent-json"
+readonly JSON_TMP_PREFIX="/tmp/Proxy-agent-json"
 
 # ============================================================================
 # 验证函数
@@ -596,7 +596,7 @@ xrayGetTLSDomain() {
 
     certPath=$(jsonGetValue "${file}" ".inbounds[0].streamSettings.tlsSettings.certificates[0].certificateFile")
     if [[ -n "${certPath}" ]]; then
-        # 从路径 /etc/v2ray-agent/tls/domain.crt 提取域名
+        # 从路径 /etc/Proxy-agent/tls/domain.crt 提取域名
         echo "${certPath}" | awk -F '[/]' '{print $(NF)}' | sed 's/\.crt$//'
     fi
 }

--- a/lib/service-control.sh
+++ b/lib/service-control.sh
@@ -126,7 +126,7 @@ handleXrayService() {
                     echoContent green " ---> Xray启动成功"
                 else
                     echoContent red "Xray启动失败"
-                    echoContent red "请手动执行: /etc/v2ray-agent/xray/xray -confdir /etc/v2ray-agent/xray/conf"
+                    echoContent red "请手动执行: /etc/Proxy-agent/xray/xray -confdir /etc/Proxy-agent/xray/conf"
                     return 1
                 fi
             fi
@@ -183,7 +183,7 @@ handleSingBoxService() {
                 else
                     echoContent red "sing-box启动失败"
                     echoContent yellow "请手动执行检查:"
-                    echoContent yellow "  /etc/v2ray-agent/sing-box/sing-box merge config.json -C /etc/v2ray-agent/sing-box/conf/config/ -D /etc/v2ray-agent/sing-box/conf/"
+                    echoContent yellow "  /etc/Proxy-agent/sing-box/sing-box merge config.json -C /etc/Proxy-agent/sing-box/conf/config/ -D /etc/Proxy-agent/sing-box/conf/"
                     return 1
                 fi
             fi

--- a/shell/lang/loader.sh
+++ b/shell/lang/loader.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Language Loader for v2ray-agent (Legacy Compatibility)
+# Language Loader for Proxy-agent (Legacy Compatibility)
 # 语言加载器 - 向后兼容层
 # =============================================================================
 # NOTE: This file is kept for backward compatibility.
@@ -9,6 +9,7 @@
 # New Usage:
 #   V2RAY_LANG=en bash install.sh    # English
 #   V2RAY_LANG=zh bash install.sh    # Chinese (default)
+#   pasly  -> Menu 21 to switch language permanently
 # =============================================================================
 
 # If lib/i18n.sh exists, delegate to it
@@ -20,7 +21,14 @@ if [[ -f "${_LIB_I18N}" ]]; then
     source "${_LIB_I18N}"
 else
     # Fallback: Direct loading (legacy mode)
-    : "${LANG_CODE:=${V2RAY_LANG:-zh_CN}}"
+    # 优先级: V2RAY_LANG > 持久配置 > 默认中文
+    if [[ -n "${V2RAY_LANG}" ]]; then
+        LANG_CODE="${V2RAY_LANG}"
+    elif [[ -f "/etc/Proxy-agent/lang_pref" ]]; then
+        LANG_CODE=$(cat "/etc/Proxy-agent/lang_pref" 2>/dev/null)
+    else
+        LANG_CODE="zh_CN"
+    fi
 
     case "${LANG_CODE}" in
         en*|EN*) LANG_CODE="en_US" ;;


### PR DESCRIPTION
Major changes:
- Rename installation directory from /etc/v2ray-agent to /etc/Proxy-agent
- Add automatic migration for existing installations
- Add menu item 21 for language switching (persistent setting)
- Update all lib/ modules with new paths
- Update documentation to reflect new project structure

Migration features:
- Automatically detects /etc/v2ray-agent and migrates to /etc/Proxy-agent
- Updates systemd service files, nginx configs, and crontab entries
- Creates compatibility symlink for smooth transition
- Stops and restarts services during migration

Language switching:
- Menu option 21: 切换语言 / Switch Language
- Saves preference to /etc/Proxy-agent/lang_pref
- Priority: V2RAY_LANG env > lang_pref file > system LANG > default (zh_CN)