### PR TITLE
fix(sing-box): use simple DNS config for 1.12+ compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8324,7 +8324,7 @@ ensureSingBoxInstalled() {
 EOF
     fi
 
-    # 确保 DNS 配置存在 (使用 sing-box 1.12+ 新格式)
+    # 确保 DNS 配置存在 (使用 sing-box 1.12+ 兼容格式)
     if [[ ! -f "/etc/Proxy-agent/sing-box/conf/config/01_dns.json" ]]; then
         cat <<EOF >/etc/Proxy-agent/sing-box/conf/config/01_dns.json
 {
@@ -8332,13 +8332,11 @@ EOF
         "servers": [
             {
                 "tag": "google",
-                "address": "https://dns.google/dns-query",
-                "detour": "direct"
+                "address": "8.8.8.8"
             },
             {
-                "tag": "local",
-                "address": "local",
-                "detour": "direct"
+                "tag": "cloudflare",
+                "address": "1.1.1.1"
             }
         ]
     }


### PR DESCRIPTION
sing-box 1.12+ no longer supports DNS servers with "detour" pointing to a simple direct outbound. Changed DNS configuration to use plain UDP DNS servers (8.8.8.8 and 1.1.1.1) which don't require detour routing.

This fixes the error:
"start dns/https[google]: detour to an empty direct outbound makes no sense"