### PR TITLE
fix(chain-proxy): exclude localhost from chain proxy routing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9272,6 +9272,11 @@ EOF
         "rules": [
             {
                 "type": "field",
+                "ip": ["127.0.0.0/8", "::1"],
+                "outboundTag": "z_direct_outbound"
+            },
+            {
+                "type": "field",
                 "domain": [
                     "domain:gstatic.com",
                     "domain:googleapis.com",
@@ -9508,6 +9513,11 @@ EOF
     "routing": {
         "domainStrategy": "AsIs",
         "rules": [
+            {
+                "type": "field",
+                "ip": ["127.0.0.0/8", "::1"],
+                "outboundTag": "z_direct_outbound"
+            },
             {
                 "type": "field",
                 "domain": [


### PR DESCRIPTION
The chain proxy routing configuration was sending ALL TCP/UDP traffic to the chain proxy, including localhost (127.0.0.1) addresses. This caused issues when internal Xray components (like dokodemo-door) tried to communicate via localhost - the requests would be forwarded to the exit node, which couldn't connect to the entry node's local ports.

Fix: Add routing rule to bypass 127.0.0.0/8 and ::1 addresses, sending them directly to z_direct_outbound instead of chain_proxy.