### PR TITLE
fix(version): fetch version from GitHub Releases on first install

### DIFF
--- a/lib/constants.sh
+++ b/lib/constants.sh
@@ -184,7 +184,7 @@ readonly XRAY_ERROR_LOG="${V2RAY_AGENT_DIR}/xray/error.log"
 # 这里只提供默认值和其他常量
 # ============================================================================
 
-: "${SCRIPT_VERSION:=v3.6.0}"  # 默认版本，如果未从VERSION文件加载
+: "${SCRIPT_VERSION:=(initial)}"  # 默认版本标识，如果未从VERSION文件加载
 readonly SCRIPT_AUTHOR="Lynthar"
 readonly SCRIPT_REPO="https://github.com/Lynthar/Proxy-agent"
 


### PR DESCRIPTION
When VERSION file is not available locally (first-time install via wget), the script now fetches the latest version from GitHub Releases API.

Priority order:
1. ./VERSION file (from git clone)
2. /etc/Proxy-agent/VERSION (after installation)
3. GitHub Releases API (first-time install)
4. "(initial)" fallback (network unavailable)

Uses short timeout (3s connect, 5s total) to avoid blocking.