### PR TITLE
refactor(protocol): remove gRPC protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ wget -P /root -N https://raw.githubusercontent.com/Lynthar/Proxy-agent/master/in
 
 | 协议 | 传输方式 | TLS | 说明 |
 |------|----------|-----|------|
-| VLESS | TCP/Vision, WS, gRPC, XHTTP | TLS/Reality | 推荐 |
+| VLESS | TCP/Vision, WS, XHTTP | TLS/Reality | 推荐 |
 | VMess | WebSocket, HTTPUpgrade | TLS | CDN 友好 |
-| Trojan | TCP, gRPC | TLS | 伪装 HTTPS |
+| Trojan | TCP | TLS | 伪装 HTTPS |
 | Hysteria2 | QUIC | 自签名 | 高速 UDP |
 | TUIC | QUIC | TLS | 低延迟 UDP |
 | NaiveProxy | HTTP/2 | TLS | 抗检测 |

--- a/documents/en/README_EN.md
+++ b/documents/en/README_EN.md
@@ -15,12 +15,12 @@ A fork of [v2ray-agent](https://github.com/mack-a/v2ray-agent), providing one-cl
 ### Supported Protocols
 | Protocol | Transport | Description |
 |----------|-----------|-------------|
-| VLESS | TCP/Vision, WebSocket, gRPC, XHTTP | Lightweight protocol |
+| VLESS | TCP/Vision, WebSocket, XHTTP | Lightweight protocol |
 | VMess | WebSocket, HTTPUpgrade | V2Ray native protocol |
-| Trojan | TCP, gRPC | HTTPS traffic disguise |
+| Trojan | TCP | HTTPS traffic disguise |
 | Hysteria2 | QUIC | High-speed UDP protocol |
 | TUIC | QUIC | Low-latency UDP protocol |
-| Reality | Vision, gRPC | No domain/certificate required |
+| Reality | Vision, XHTTP | No domain/certificate required |
 | NaiveProxy | - | Anti-detection protocol |
 | Shadowsocks 2022 | - | Next-gen SS protocol |
 | AnyTLS | - | Universal TLS protocol |

--- a/lib/constants.sh
+++ b/lib/constants.sh
@@ -18,13 +18,13 @@ readonly _CONSTANTS_LOADED=1
 
 readonly PROTOCOL_VLESS_TCP_VISION=0      # VLESS+TCP+TLS+Vision
 readonly PROTOCOL_VLESS_WS=1              # VLESS+WebSocket+TLS
-readonly PROTOCOL_TROJAN_GRPC=2           # Trojan+gRPC+TLS (已注释)
+readonly PROTOCOL_TROJAN_GRPC=2           # Trojan+gRPC+TLS (已废弃，推荐XHTTP)
 readonly PROTOCOL_VMESS_WS=3              # VMess+WebSocket+TLS
 readonly PROTOCOL_TROJAN_TCP=4            # Trojan+TCP+TLS
-readonly PROTOCOL_VLESS_GRPC=5            # VLESS+gRPC+TLS
+readonly PROTOCOL_VLESS_GRPC=5            # VLESS+gRPC+TLS (已废弃，推荐XHTTP)
 readonly PROTOCOL_HYSTERIA2=6             # Hysteria2
 readonly PROTOCOL_VLESS_REALITY_VISION=7  # VLESS+Reality+Vision
-readonly PROTOCOL_VLESS_REALITY_GRPC=8    # VLESS+Reality+gRPC
+readonly PROTOCOL_VLESS_REALITY_GRPC=8    # VLESS+Reality+gRPC (已废弃，推荐XHTTP)
 readonly PROTOCOL_TUIC=9                  # TUIC
 readonly PROTOCOL_NAIVE=10                # NaiveProxy
 readonly PROTOCOL_VMESS_HTTPUPGRADE=11    # VMess+HTTPUpgrade+TLS

--- a/lib/protocol-registry.sh
+++ b/lib/protocol-registry.sh
@@ -27,13 +27,13 @@ getProtocolConfigFileName() {
     case "${protocolId}" in
         0)  echo "02_VLESS_TCP_inbounds.json" ;;
         1)  echo "03_VLESS_WS_inbounds.json" ;;
-        2)  echo "04_trojan_gRPC_inbounds.json" ;;
+        2)  echo "04_trojan_gRPC_inbounds.json" ;;  # 已废弃
         3)  echo "05_VMess_WS_inbounds.json" ;;
         4)  echo "04_trojan_TCP_inbounds.json" ;;
-        5)  echo "06_VLESS_gRPC_inbounds.json" ;;
+        5)  echo "06_VLESS_gRPC_inbounds.json" ;;  # 已废弃
         6)  echo "06_hysteria2_inbounds.json" ;;
         7)  echo "07_VLESS_vision_reality_inbounds.json" ;;
-        8)  echo "08_VLESS_vision_gRPC_inbounds.json" ;;
+        8)  echo "08_VLESS_vision_gRPC_inbounds.json" ;;  # 已废弃
         9)  echo "09_tuic_inbounds.json" ;;
         10) echo "10_naive_inbounds.json" ;;
         11) echo "11_VMess_HTTPUpgrade_inbounds.json" ;;


### PR DESCRIPTION
gRPC transport has been deprecated in favor of XHTTP (SplitHTTP) which offers better anti-detection capabilities and CDN compatibility.

Removed protocols:
- Protocol 2: Trojan+gRPC+TLS (was already commented out)
- Protocol 5: VLESS+gRPC+TLS
- Protocol 8: VLESS+Reality+gRPC

Changes:
- Disable gRPC options in install menus (Xray/sing-box)
- Remove gRPC configuration generation code
- Remove Nginx gRPC location blocks
- Remove gRPC user add/delete logic
- Remove gRPC account display code
- Update lib modules with deprecation comments
- Update README documentation

The protocol ID constants (2, 5, 8) are preserved for backward compatibility with existing installations that may need cleanup.