### PR TITLE
fix(sing-box): ensure direct outbound exists after initSingBoxConfig

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5470,6 +5470,18 @@ EOF
         removeSingBoxConfig socks5_outbound.json
         removeSingBoxConfig block_domain_outbound
         removeSingBoxConfig dns
+
+        # 确保基础 direct 出站存在，sing-box 需要至少一个默认出站
+        cat <<EOF >/etc/Proxy-agent/sing-box/conf/config/01_direct_outbound.json
+{
+    "outbounds": [
+        {
+            "type": "direct",
+            "tag": "direct"
+        }
+    ]
+}
+EOF
     fi
 }
 # 初始化 sing-box订阅配置


### PR DESCRIPTION
When user installs only Naive protocol (or other sing-box protocols without additional routing), the initSingBoxConfig function would remove all outbound configs including 01_direct_outbound.json, leaving sing-box without any default outbound.

This caused sing-box to fail with:
  FATAL: start service: default outbound not found: direct

Fix: After removing routing-related configs, always recreate the basic direct outbound to ensure sing-box has a valid default outbound.